### PR TITLE
Update scripts.tmpl.partial

### DIFF
--- a/templates/lightbox-featherlight/partials/scripts.tmpl.partial
+++ b/templates/lightbox-featherlight/partials/scripts.tmpl.partial
@@ -3,6 +3,5 @@
 <script type="text/javascript" src="{{_rel}}styles/docfx.vendor.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/docfx.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/main.js"></script>
-<script src="//code.jquery.com/jquery-latest.js"></script>
 <script src="//cdn.rawgit.com/noelboss/featherlight/1.7.6/release/featherlight.min.js" type="text/javascript" charset="utf-8"></script>
 <script type="text/javascript" src="{{_rel}}styles/plugin-featherlight.js"></script>


### PR DESCRIPTION
Addresses [this bug](https://github.com/roel4ez/docfx-lightbox-plugin/issues/2)

When I tried to implement this plugin within DocFx, lightbox worked but search ceased to work. I think it may have to do with conflicting versions of jQuery. DocFx seems to be on 2.1.4. When I removed this line, both lightbox and search worked.